### PR TITLE
styleBot prototype

### DIFF
--- a/styleBot.py
+++ b/styleBot.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+#This script finds style errors and sends feedback to the command line
+
+import sys
+
+
+myFile = sys.argv[1]
+
+data =  open(myFile, 'r', encoding = None, errors = 'ignore')
+myPage = "<!doctype html> "
+#myPage = []
+lineCount = 0
+
+#cut lines containing unwanted text string
+for line in data:
+     lineCount = lineCount + 1
+     if isinstance(line, str) == True:
+        if 'aint' in line:
+            print("line ", lineCount, ": Warning: Aint is an improper usage. Try 'am not' or 'are not' or something else.")
+        if ' -- ' in line:
+            print("line ", lineCount, ": Warning: Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.")
+        else:
+           continue
+     else:
+        print("not string")
+
+
+
+
+print("Review completed.")

--- a/styleBot.py
+++ b/styleBot.py
@@ -1,30 +1,36 @@
-#!/usr/bin/python3
-#This script finds style errors and sends feedback to the command line
+#!/Library/Frameworks/Python.framework/Versions/3.6/bin/python3
 
+
+
+
+#Get filename from command line input
 import sys
-
-
 myFile = sys.argv[1]
+print("styleBot is checking ", myFile)
 
+# open file and initiate line counter
 data =  open(myFile, 'r', encoding = None, errors = 'ignore')
-myPage = "<!doctype html> "
-#myPage = []
+paragraphCount = 0
 lineCount = 0
 
-#cut lines containing unwanted text string
+# Check each line against checklist of potential errors
 for line in data:
-     lineCount = lineCount + 1
-     if isinstance(line, str) == True:
-        if 'aint' in line:
-            print("line ", lineCount, ": Warning: Aint is an improper usage. Try 'am not' or 'are not' or something else.")
-        if ' -- ' in line:
-            print("line ", lineCount, ": Warning: Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.")
+    myLines = line.split(".")
+    paragraphCount = paragraphCount + 1
+    lineCount = 0
+    for sentence in myLines:
+        lineCount = lineCount + 1
+        if isinstance(line, str) == True:
+           if 'aint' in sentence:
+              print("Par",paragraphCount,", Sen",lineCount, ": Warning! Aint is an improper usage. Try 'am not' or 'are not' or something else.")
+           if '--' in sentence:
+              print("Par",paragraphCount,", Sen",lineCount, ": Warning! Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.")
+           if ' -- ' in sentence:
+              print("Par",paragraphCount,", Sen",lineCount, ": Warning! Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.")
+
+           else:
+              continue
         else:
-           continue
-     else:
-        print("not string")
-
-
-
-
+           print("not string data")
+# Indicate the end of the process in the command line
 print("Review completed.")


### PR DESCRIPTION
This Python script is capable of checking for two kinds of errors: 
-presence of the word 'aint' 
-usage of two consecutive hyphens, instead of an em-dash

The middle section of the script could be filled out by adding many more tests, as we figure out how to most efficiently test for each item. 

It might be more effective to use regex for some of these. I'm not really an expert user, but it would probably be a good way to specify, for example, that you _don't_ want to see two hyphens in a sequence, whether they have spaces before and after, or not. That would give many of the tests the following format.

`if <regex here> in sentence: `

Also, this could be rewritten in JavaScript. I just happened to have a Python script handy that was easy to convert. 

Here is some sample output from this script, when run against a three-paragraph text file called badStyle.txt, with lots of offenses against these two rules: 

$ ./styleBot.py badStyle.txt
styleBot is checking  badStyle.txt
Par 1 , Sen 1 : Warning! Aint is an improper usage. Try 'am not' or 'are not' or something else.
Par 2 , Sen 1 : Warning! Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.
Par 2 , Sen 1 : Warning! Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.
Par 2 , Sen 3 : Warning! Aint is an improper usage. Try 'am not' or 'are not' or something else.
Par 3 , Sen 1 : Warning! Two consecutive hyphens. Try replacing with an em-dash. You can use alt+0151 on the PC or Command + hyphen on the Mac.
Review completed.
$ 


